### PR TITLE
feat: Add command-line options for custom API URL and User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Plus `final_answer` — a structured submission tool the agent calls when done.
 ### 1. Clone and Configure
 
 ```bash
-git clone https://github.com/your-org/AgentRE-Bench.git
+git clone https://github.com/dyussekeyev/AgentRE-Bench.git
 cd AgentRE-Bench
 
 # Create .env with your API key(s)

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ python run_benchmark.py --all --report results/opus_run1/
 | `--provider` | `anthropic` | `anthropic`, `openai`, `gemini`, `deepseek` |
 | `--model` | per-provider | Model name |
 | `--api-key` | from .env | API key override |
+| `--api-url` | per-provider | Base URL for the provider API |
+| `--user-agent` | | Custom User-Agent header for API requests |
 | `--report DIR` | `results/` | Output directory |
 | `--max-tool-calls` | `25` | Tool call budget per task |
 | `--max-tokens` | `4096` | Max tokens per LLM response |

--- a/harness/agent.py
+++ b/harness/agent.py
@@ -159,6 +159,7 @@ class AgentLoop:
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": tc.id,
+                        "tool_name": tc.name,
                         "content": output_text,
                     })
 

--- a/harness/config.py
+++ b/harness/config.py
@@ -48,6 +48,8 @@ class BenchmarkConfig:
     model: str = "claude-opus-4-6"
     provider: str = "anthropic"
     api_key: str = ""
+    api_url: str | None = None
+    user_agent: str | None = None
 
     max_tool_calls: int = 25
     tool_timeout_seconds: int = 30

--- a/harness/providers/__init__.py
+++ b/harness/providers/__init__.py
@@ -12,11 +12,11 @@ PROVIDER_MAP = {
 }
 
 
-def create_provider(provider_name: str, model: str, api_key: str) -> AgentProvider:
+def create_provider(provider_name: str, model: str, api_key: str, api_url: str | None = None, user_agent: str | None = None) -> AgentProvider:
     cls = PROVIDER_MAP.get(provider_name)
     if cls is None:
         raise ValueError(
             f"Unknown provider {provider_name!r}. "
             f"Choose from: {', '.join(PROVIDER_MAP)}"
         )
-    return cls(api_key=api_key, model=model)
+    return cls(api_key=api_key, model=model, api_url=api_url, user_agent=user_agent)

--- a/harness/providers/anthropic.py
+++ b/harness/providers/anthropic.py
@@ -14,9 +14,11 @@ API_VERSION = "2023-06-01"
 
 
 class AnthropicProvider(AgentProvider):
-    def __init__(self, api_key: str, model: str):
+    def __init__(self, api_key: str, model: str, api_url: str | None = None, user_agent: str | None = None):
         self.api_key = api_key
         self.model = model
+        self.api_url = api_url or API_URL
+        self.user_agent = user_agent
 
     def create_message(
         self,
@@ -38,9 +40,11 @@ class AnthropicProvider(AgentProvider):
             "x-api-key": self.api_key,
             "anthropic-version": API_VERSION,
         }
+        if self.user_agent:
+            headers["User-Agent"] = self.user_agent
 
         data = json.dumps(body).encode("utf-8")
-        req = urllib.request.Request(API_URL, data=data, headers=headers, method="POST")
+        req = urllib.request.Request(self.api_url, data=data, headers=headers, method="POST")
 
         try:
             with urllib.request.urlopen(req, timeout=300) as resp:

--- a/harness/providers/base.py
+++ b/harness/providers/base.py
@@ -22,6 +22,10 @@ class ProviderResponse:
 
 
 class AgentProvider(ABC):
+    """
+    Abstract base class for LLM providers.
+    Subclasses should implement __init__(self, api_key: str, model: str, api_url: str | None = None, user_agent: str | None = None)
+    """
     @abstractmethod
     def create_message(
         self,

--- a/harness/providers/deepseek.py
+++ b/harness/providers/deepseek.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from .openai_provider import OpenAIProvider
 
-DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+API_URL = "https://api.deepseek.com"
 
 
 class DeepSeekProvider(OpenAIProvider):
-    def __init__(self, api_key: str, model: str):
-        super().__init__(api_key=api_key, model=model, base_url=DEEPSEEK_BASE_URL)
+    def __init__(self, api_key: str, model: str, api_url: str | None = None, user_agent: str | None = None):
+        super().__init__(api_key=api_key, model=model, api_url=api_url or API_URL, user_agent=user_agent)
 
     def _token_param(self) -> str:
         return "max_tokens"

--- a/harness/providers/gemini.py
+++ b/harness/providers/gemini.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import urllib.error
 import urllib.request
 
 from .base import AgentProvider, ProviderResponse, ToolCall

--- a/harness/providers/gemini.py
+++ b/harness/providers/gemini.py
@@ -13,9 +13,11 @@ API_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 
 class GeminiProvider(AgentProvider):
-    def __init__(self, api_key: str, model: str):
+    def __init__(self, api_key: str, model: str, api_url: str | None = None, user_agent: str | None = None):
         self.api_key = api_key
         self.model = model
+        self.api_url = (api_url or API_URL).rstrip("/")
+        self.user_agent = user_agent
 
     def create_message(
         self,
@@ -33,8 +35,10 @@ class GeminiProvider(AgentProvider):
             "generationConfig": {"maxOutputTokens": max_tokens},
         }
 
-        url = f"{API_URL}/{self.model}:generateContent?key={self.api_key}"
+        url = f"{self.api_url}/{self.model}:generateContent?key={self.api_key}"
         headers = {"Content-Type": "application/json"}
+        if self.user_agent:
+            headers["User-Agent"] = self.user_agent
         data = json.dumps(body).encode("utf-8")
         req = urllib.request.Request(url, data=data, headers=headers, method="POST")
 

--- a/harness/providers/openai_provider.py
+++ b/harness/providers/openai_provider.py
@@ -9,14 +9,15 @@ from ..tools import schemas_to_openai
 
 log = logging.getLogger(__name__)
 
-DEFAULT_BASE_URL = "https://api.openai.com/v1"
+API_URL = "https://api.openai.com/v1"
 
 
 class OpenAIProvider(AgentProvider):
-    def __init__(self, api_key: str, model: str, base_url: str | None = None):
+    def __init__(self, api_key: str, model: str, api_url: str | None = None, user_agent: str | None = None):
         self.api_key = api_key
         self.model = model
-        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self.api_url = (api_url or API_URL).rstrip("/")
+        self.user_agent = user_agent
 
     def _token_param(self) -> str:
         """Parameter name for max output tokens. Override for API compatibility."""
@@ -46,9 +47,11 @@ class OpenAIProvider(AgentProvider):
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.api_key}",
         }
+        if self.user_agent:
+            headers["User-Agent"] = self.user_agent
 
         data = json.dumps(body).encode("utf-8")
-        url = f"{self.base_url}/chat/completions"
+        url = f"{self.api_url}/chat/completions"
         req = urllib.request.Request(url, data=data, headers=headers, method="POST")
 
         with urllib.request.urlopen(req, timeout=300) as resp:

--- a/harness/runner.py
+++ b/harness/runner.py
@@ -105,7 +105,7 @@ def run_single_task(
 
     # Create provider
     api_key = config.resolve_api_key()
-    provider = create_provider(config.provider, config.model, api_key)
+    provider = create_provider(config.provider, config.model, api_key, config.api_url, config.user_agent)
 
     # Build system prompt
     system_prompt = build_system_prompt(task, config)

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -63,6 +63,18 @@ def main():
         help="API key override (normally loaded from .env or environment)",
     )
     parser.add_argument(
+        "--api-url",
+        type=str,
+        default=None,
+        help="Base URL for the provider API",
+    )
+    parser.add_argument(
+        "--useragent",
+        type=str,
+        default=None,
+        help="Custom User-Agent header for API requests",
+    )
+    parser.add_argument(
         "--report",
         type=str,
         default=None,
@@ -114,6 +126,8 @@ def main():
         model=model,
         provider=args.provider,
         api_key=args.api_key,
+        api_url=args.api_url,
+        user_agent=args.useragent,
         max_tool_calls=args.max_tool_calls,
         max_tokens=args.max_tokens,
         use_docker=not args.no_docker,

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -127,7 +127,7 @@ def main():
         provider=args.provider,
         api_key=args.api_key,
         api_url=args.api_url,
-        user_agent=args.useragent,
+        user_agent=args.user_agent,
         max_tool_calls=args.max_tool_calls,
         max_tokens=args.max_tokens,
         use_docker=not args.no_docker,

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -69,7 +69,7 @@ def main():
         help="Base URL for the provider API",
     )
     parser.add_argument(
-        "--useragent",
+        "--user-agent",
         type=str,
         default=None,
         help="Custom User-Agent header for API requests",


### PR DESCRIPTION
### Description

This PR introduces the ability to override the default provider API endpoints and inject a custom `User-Agent` header via the command line. This is particularly useful for routing requests through proxies or bypassing services like Cloudflare that might block the default `urllib` User-Agent.

### Changes made
- Unified URL constants across all provider scripts (`DEEPSEEK_BASE_URL`, `DEFAULT_BASE_URL`, etc.) into a standard `API_URL`.
- Added `--api-url` flag to `run_benchmark.py` to allow users to override the default API endpoint for the selected provider.
- Added `--user-agent` flag to inject a custom `User-Agent` header into the `urllib.request` calls.
- Plumbed the new variables through `BenchmarkConfig` and the `create_provider` factory.
- Fixed a minor typo in the `README.md` clone command (`your-org` -> `dyussekeyev`). 

### Testing
- Validated that the CLI correctly parses `--api-url` and `--user-agent`.
- Confirmed that the custom `User-Agent` is properly appended to the HTTP headers in provider scripts (`openai_provider`, `anthropic`, `gemini`, `deepseek`).
