### PR TITLE
Fixing bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Plus `final_answer` — a structured submission tool the agent calls when done.
 ### 1. Clone and Configure
 
 ```bash
-git clone https://github.com/your-org/AgentRE-Bench.git
+git clone https://github.com/agentrebench/AgentRE-Bench.git
 cd AgentRE-Bench
 
 # Create .env with your API key(s)

--- a/harness/agent.py
+++ b/harness/agent.py
@@ -243,6 +243,7 @@ class AgentLoop:
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": tc.id,
+                        "tool_name": tc.name,
                         "content": output_text,
                     })
 

--- a/harness/providers/gemini.py
+++ b/harness/providers/gemini.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import urllib.error
 import urllib.request
 
 from .base import AgentProvider, ProviderResponse, ToolCall


### PR DESCRIPTION
Bug in agent.py — add `tool_name` to `tool_result` dict
  Gemini provider needs `tool_name` in `tool_result` blocks to construct
  `functionResponse`. Without it, all tool responses were mapped to
  'unknown', breaking Gemini provider functionality.

Bug in gemini.py — add missing `import urllib.error`
  `urllib.error` is not auto-loaded when importing `urllib.request`.
  Without this import, the except HTTPError clause would fail with
  `NameError` when an HTTP error occurs.

Fixing GitHub repository URL in `README`.